### PR TITLE
Do not stop if ARCHIVE_FILENAME is corrupt

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -27,8 +27,11 @@ if [ "${ARCHIVE_SHA1}" != "" ]; then
     sha1sum -c $tmpfile
 fi
 
+# FIXME: ARCHIVE_FILENAME=VF785_20140321.tar.xz returns error
+# Append "|| true" to prevent the script to stop
+
 echo "INFO: Extracting file contents..."
-tar xpvf ${ARCHIVE_FILENAME}
+tar xpvf ${ARCHIVE_FILENAME} || true
 
 rm -f $tmpfile
 


### PR DESCRIPTION
Apparently VF785_20140321.tar.xz is corrupt and the following error
is returned when extracting the archive:

```
...
VF785/external/webkit/Source/WebCore/html/PluginDocument.h
VF785/external/webkit/Source/WebCore/CMakeListsWinCE.txt
VF785/external/webkit/Source/WebCore/ChangeLog-2005-12-19
xz: (stdin): Unexpected end of input
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
```

Appending "|| true" to prevent the script to break.

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
